### PR TITLE
Fix copilot cli version to 1.32.0

### DIFF
--- a/.github/workflows/deploy_omcare_cloud_iac.yml
+++ b/.github/workflows/deploy_omcare_cloud_iac.yml
@@ -41,35 +41,40 @@ jobs:
           aws-region: ${{ inputs.region }}
       
       - name: Install AWS Copilot CLI
-        uses: ksivamuthu/aws-copilot-github-action@v0.0.1
-        with:
-          command: install
+        # uses: ksivamuthu/aws-copilot-github-action@v0.0.1
+        # with:
+        #   command: install
+        run: |
+          sudo curl -Lo /usr/local/bin/copilot https://github.com/aws/copilot-cli/releases/download/v1.32.0/copilot-linux-v1.32.0 \
+            && sudo chmod +x /usr/local/bin/copilot \
+            && copilot --help
+            && copilot --version
       
-      - name: Execute Copilot Deployment Script
-        env:
-          GITHUB_SHA: ${{ inputs.github_sha }}
-          REGION: ${{ inputs.region }}
-          ACCOUNT: ${{ inputs.account }}
-          APP_NAME: ${{ inputs.app_name }}
-          ENVIRONMENT: ${{ inputs.environment }}
-        run: |
-          copilot --version
-          ./scripts/copilot-deploy.sh
+      # - name: Execute Copilot Deployment Script
+      #   env:
+      #     GITHUB_SHA: ${{ inputs.github_sha }}
+      #     REGION: ${{ inputs.region }}
+      #     ACCOUNT: ${{ inputs.account }}
+      #     APP_NAME: ${{ inputs.app_name }}
+      #     ENVIRONMENT: ${{ inputs.environment }}
+      #   run: |
+      #     copilot --version
+      #     ./scripts/copilot-deploy.sh
 
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
+      # - name: Set up Node
+      #   uses: actions/setup-node@v3
+      #   with:
+      #     node-version: "18"
 
-      - name: Deploy OmcareCloud CDK App
-        env:
-          CDK_DEFAULT_REGION: ${{ inputs.region }}
-          CDK_DEFAULT_ACCOUNT: ${{ inputs.account }}
-          ENVIRONMENT: ${{ inputs.environment }}
-        run: |
-          cd omcare-cloud-cdk
-          npm i
-          npx cdk bootstrap -c environment=$ENVIRONMENT
-          npx cdk diff -c environment=$ENVIRONMENT
-          npx cdk deploy --all --require-approval=never -c environment=$ENVIRONMENT
+      # - name: Deploy OmcareCloud CDK App
+      #   env:
+      #     CDK_DEFAULT_REGION: ${{ inputs.region }}
+      #     CDK_DEFAULT_ACCOUNT: ${{ inputs.account }}
+      #     ENVIRONMENT: ${{ inputs.environment }}
+      #   run: |
+      #     cd omcare-cloud-cdk
+      #     npm i
+      #     npx cdk bootstrap -c environment=$ENVIRONMENT
+      #     npx cdk diff -c environment=$ENVIRONMENT
+      #     npx cdk deploy --all --require-approval=never -c environment=$ENVIRONMENT
 

--- a/.github/workflows/deploy_omcare_cloud_iac.yml
+++ b/.github/workflows/deploy_omcare_cloud_iac.yml
@@ -41,40 +41,36 @@ jobs:
           aws-region: ${{ inputs.region }}
       
       - name: Install AWS Copilot CLI
-        # uses: ksivamuthu/aws-copilot-github-action@v0.0.1
-        # with:
-        #   command: install
         run: |
           sudo curl -Lo /usr/local/bin/copilot https://github.com/aws/copilot-cli/releases/download/v1.32.0/copilot-linux-v1.32.0 \
             && sudo chmod +x /usr/local/bin/copilot \
-            && copilot --help
             && copilot --version
       
-      # - name: Execute Copilot Deployment Script
-      #   env:
-      #     GITHUB_SHA: ${{ inputs.github_sha }}
-      #     REGION: ${{ inputs.region }}
-      #     ACCOUNT: ${{ inputs.account }}
-      #     APP_NAME: ${{ inputs.app_name }}
-      #     ENVIRONMENT: ${{ inputs.environment }}
-      #   run: |
-      #     copilot --version
-      #     ./scripts/copilot-deploy.sh
+      - name: Execute Copilot Deployment Script
+        env:
+          GITHUB_SHA: ${{ inputs.github_sha }}
+          REGION: ${{ inputs.region }}
+          ACCOUNT: ${{ inputs.account }}
+          APP_NAME: ${{ inputs.app_name }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          copilot --version
+          ./scripts/copilot-deploy.sh
 
-      # - name: Set up Node
-      #   uses: actions/setup-node@v3
-      #   with:
-      #     node-version: "18"
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
 
-      # - name: Deploy OmcareCloud CDK App
-      #   env:
-      #     CDK_DEFAULT_REGION: ${{ inputs.region }}
-      #     CDK_DEFAULT_ACCOUNT: ${{ inputs.account }}
-      #     ENVIRONMENT: ${{ inputs.environment }}
-      #   run: |
-      #     cd omcare-cloud-cdk
-      #     npm i
-      #     npx cdk bootstrap -c environment=$ENVIRONMENT
-      #     npx cdk diff -c environment=$ENVIRONMENT
-      #     npx cdk deploy --all --require-approval=never -c environment=$ENVIRONMENT
+      - name: Deploy OmcareCloud CDK App
+        env:
+          CDK_DEFAULT_REGION: ${{ inputs.region }}
+          CDK_DEFAULT_ACCOUNT: ${{ inputs.account }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          cd omcare-cloud-cdk
+          npm i
+          npx cdk bootstrap -c environment=$ENVIRONMENT
+          npx cdk diff -c environment=$ENVIRONMENT
+          npx cdk deploy --all --require-approval=never -c environment=$ENVIRONMENT
 

--- a/.github/workflows/deploy_omcare_cloud_iac.yml
+++ b/.github/workflows/deploy_omcare_cloud_iac.yml
@@ -54,7 +54,6 @@ jobs:
           APP_NAME: ${{ inputs.app_name }}
           ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          copilot --version
           ./scripts/copilot-deploy.sh
 
       - name: Set up Node


### PR DESCRIPTION
"
Note: Starting with v1.33.0, Copilot will start applying a security group to your network load balancer. This allows more fine-grained intra-VPC access control: your service won't need to allow-list the CIDR blocks of the public subnets where the NLB is deployed; it only needs to allow-list the NLB, specifically.

NLB security group onboarding implies resource recreation, because a security group can't be added to an existing NLB that does not already have one. Therefore, after v1.33.0, you might see some resource recreation related to your NLB. This means:
1. If you don't use DNS aliases, then the NLB's domain name will change.
2. If you use DNS aliases, then the aliases will start pointing to the new NLB that is enhanced with a security group.

For more on NLB security groups, please see https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-security-groups.html.
"

We don't want the domain name of the NLB to change suddenly, that would cause a downage of the Cloud services